### PR TITLE
Fix dependency issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,4 +14,4 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,5 @@
 export(AddModuleScore_UCell)
 export(ScoreSignatures_UCell)
 export(StoreRankings_UCell)
+import(Seurat)
+import(data.table)

--- a/R/main.R
+++ b/R/main.R
@@ -37,6 +37,7 @@
 #' SeuratObject <- AddModuleScore_UCell(SeuratObject, features = markers)
 #' FeaturePlot(SeuratObject, features=c("Tcell_gd_UCell","Tcell_NK_UCell"))
 #' ## End (Not run)
+#' @import Seurat
 #' @export
 AddModuleScore_UCell <- function(obj, features, maxRank=1500, chunk.size=1000, ncores=1, storeRanks=F, w_neg=1,
                                  assay=NULL, slot="data", ties.method="average", force.gc=FALSE, seed=123, name="_UCell") {
@@ -61,7 +62,7 @@ AddModuleScore_UCell <- function(obj, features, maxRank=1500, chunk.size=1000, n
                                  ncores=ncores, force.gc=force.gc, name=name)
 
   } else {
-    meta.list <- calculate_Uscore(GetAssayData(obj, slot, assay=assay), features=features, maxRank=maxRank, chunk.size=chunk.size, w_neg=w_neg,
+    meta.list <- calculate_Uscore(Seurat::GetAssayData(obj, slot, assay=assay), features=features, maxRank=maxRank, chunk.size=chunk.size, w_neg=w_neg,
                                   ncores=ncores, ties.method=ties.method, force.gc=force.gc, storeRanks=storeRanks, name=name)
     
     #store ranks matrix?

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,6 +55,7 @@ check_signature_names <- function(features) {
 }
 
 #Calculate AUC for a list of signatures, from a ranks matrix
+#' @import data.table
 u_stat_signature_list <- function(sig_list, ranks_matrix, maxRank=1000, sparse=F, w_neg=1) {
 
   u_matrix <- sapply(sig_list, function(sig) {
@@ -84,6 +85,7 @@ u_stat_signature_list <- function(sig_list, ranks_matrix, maxRank=1000, sparse=F
 }
 
 # Calculate features' ranks from expression data matrices
+#' @import data.table
 data_to_ranks_data_table = function(data, ties.method="average") {
   dt <- as.data.table(as.matrix(data))
   rnaDT.ranks.dt <- dt[, lapply(.SD, function(x) frankv(x,ties.method=ties.method,order=c(-1L)))]
@@ -108,7 +110,7 @@ split_data.matrix <- function(matrix, chunk.size=1000) {
 }
 
 #Get signature scores from precomputed rank matrix
-
+#' @import data.table
 rankings2Uscore <- function(ranks_matrix, features, chunk.size=1000, w_neg=1,
                             ncores=1, force.gc=FALSE, name="_UCell") {
 


### PR DESCRIPTION
Importing UCell from other packages caused dependency issues related to Seurat and data.table packages. Fixed this by adding roxygen headers in `AddModuleScore_UCell`, `u_stat_signature_list`, `data_to_ranks_data_table`, and `rankings2Uscore` functions and regenerating NAMESPACE by `roxygen2::roxygenise()`.